### PR TITLE
Handle Null Values in Banner Stream Initialization to Prevent Crash

### DIFF
--- a/lib/src/banner_view.dart
+++ b/lib/src/banner_view.dart
@@ -12,8 +12,14 @@ const String _viewType = '<cas-banner-view>';
 final _stream =
     const EventChannel('com.cleveradssolutions.cas.ads.flutter.bannerview')
         .receiveBroadcastStream()
-        .map((event) =>
-            BannerViewChannelEvent(event["id"], event["event"], event["data"]));
+        .where((event) => event != null && event is Map)
+        .map((event) {
+  //Null check to avoid runtime error
+  final id = event["id"] as String? ?? '';
+  final eventName = event["event"] as String? ?? '';
+  final data = event["data"];
+  return BannerViewChannelEvent(id, eventName, data);
+});
 
 const Map<AdSize, Size> _sizes = {
   AdSize.Banner: Size(320, 50),
@@ -74,7 +80,8 @@ class BannerViewState extends State<BannerView> {
     _channel =
         MethodChannel('com.cleveradssolutions.cas.ads.flutter.bannerview.$id');
     sub = _stream.listen((event) {
-      if (event.id == id) {
+      //Null check to avoid runtime error
+      if (event.id == id && event.event != null && event.event.isNotEmpty) {
         handleEvent(event);
       }
     });


### PR DESCRIPTION
Problem

A fatal exception was occurring in banner_view.dart due to the following error:

`Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: type 'Null' is not a subtype of type 'String'
at _stream.<fn>(banner_view.dart:16)
`

This issue was caused by the delay in receiving data from the server when initializing banners. When the banner stream was initialized with a null value before the server responded with the actual data, it resulted in the application throwing an exception.
Solution

I have implemented a fix to properly handle null values during the initialization of the banner stream. Now, the stream will safely manage scenarios where the data is not yet available, preventing the crash from occurring.