### PR TITLE
Release 0.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.7.5
-### Features
+### Bug Fixes
 - Fixed a bug where `OnDismissListener` callback was not called.
 
 ## 0.7.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.7.6
+### Changes
+- [Android] (From DTExchange SDK update) Fixed usage of Android Advertising ID to be compliant with Google Play Ads policy.
+- [iOS] Requires apps to build with Xcode 16.1 or above
+### Bug Fixes
+- Fixed an issue where the banner was white.
+- Fixed an issue with the wrong argument type in the `onAdViewFailed` method.
+
 ## 0.7.5
 ### Bug Fixes
 - Fixed a bug where `OnDismissListener` callback was not called.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## 0.7.6
+### Features
+- Wraps [Android](https://github.com/cleveradssolutions/CAS-Android/releases) and [iOS](https://github.com/cleveradssolutions/CAS-iOS/releases) 3.9.9 SDK.
 ### Changes
 - [Android] (From DTExchange SDK update) Fixed usage of Android Advertising ID to be compliant with Google Play Ads policy.
-- [iOS] Requires apps to build with Xcode 16.1 or above
+- [iOS] Requires apps to build with Xcode 16.1 or above.
 ### Bug Fixes
 - Fixed an issue where the banner was white.
 - Fixed an issue with the wrong argument type in the `onAdViewFailed` method.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.cleveradssolutions.plugin.flutter'
-version = '0.7.5'
+version = '0.7.6'
 
 buildscript {
     ext.kotlin_version = '1.8.22'
@@ -97,5 +97,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.cleveradssolutions:cas-sdk:3.9.8'
+    implementation 'com.cleveradssolutions:cas-sdk:3.9.9'
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,4 +4,11 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
+
+    <application>
+        <!--    Fix WebView is white    -->
+        <meta-data
+            android:name="io.flutter.embedding.android.EnableImpeller"
+            android:value="false" />
+    </application>
 </manifest>

--- a/android/src/main/kotlin/com/cleveradssolutions/plugin/flutter/CASFlutter.kt
+++ b/android/src/main/kotlin/com/cleveradssolutions/plugin/flutter/CASFlutter.kt
@@ -36,12 +36,10 @@ class CASFlutter : FlutterPlugin, ActivityAware {
         )
         TargetingOptionsMethodHandler(binding)
 
+        val bannerViewFactory = BannerViewFactory(binding, mediationManagerMethodHandler)
         binding
             .platformViewRegistry
-            .registerViewFactory(
-                "<cas-banner-view>",
-                BannerViewFactory(binding, mediationManagerMethodHandler)
-            )
+            .registerViewFactory("<cas-banner-view>", bannerViewFactory)
     }
 
     override fun onDetachedFromEngine(binding: FlutterPluginBinding) {}

--- a/android/src/main/kotlin/com/cleveradssolutions/plugin/flutter/bannerview/BannerCallback.kt
+++ b/android/src/main/kotlin/com/cleveradssolutions/plugin/flutter/bannerview/BannerCallback.kt
@@ -16,11 +16,15 @@ class BannerCallback(
 
     override fun onAdViewLoaded(view: CASBannerView) {
         invokeMethod("onAdViewLoaded")
-        sizeListener.updateSize(view.size)
+
+        val size = view.size
+        sizeListener.updateSize(size.width, size.height)
     }
 
     override fun onAdViewFailed(view: CASBannerView, error: AdError) {
         invokeMethod("onAdViewFailed", "error" to error.message)
+
+        sizeListener.updateSize(0, 0)
     }
 
     override fun onAdViewPresented(view: CASBannerView, info: AdImpression) {

--- a/android/src/main/kotlin/com/cleveradssolutions/plugin/flutter/bannerview/BannerView.kt
+++ b/android/src/main/kotlin/com/cleveradssolutions/plugin/flutter/bannerview/BannerView.kt
@@ -25,7 +25,6 @@ class BannerView(
     init {
         banner.id = viewId
         banner.adListener = BannerCallback(sizeListener, methodHandler, id)
-        banner.viewTreeObserver.addOnGlobalLayoutListener(sizeListener)
 
         methodHandler[id] = this
 
@@ -73,7 +72,6 @@ class BannerView(
     }
 
     override fun dispose() {
-        banner.viewTreeObserver.removeOnGlobalLayoutListener(sizeListener)
         banner.destroy()
     }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "kotlin-android"
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id "dev.flutter.flutter-gradle-plugin"
-    id("com.cleveradssolutions.gradle-plugin") version "3.9.8.2"
+    id("com.cleveradssolutions.gradle-plugin") version "3.9.9"
 }
 
 cas {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "kotlin-android"
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id "dev.flutter.flutter-gradle-plugin"
-    id("com.cleveradssolutions.gradle-plugin") version "3.9.8"
+    id("com.cleveradssolutions.gradle-plugin") version "3.9.8.2"
 }
 
 cas {
@@ -67,6 +67,27 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
+        }
+    }
+
+    flavorDimensions "default"
+
+    productFlavors {
+        free {
+            dimension "default"
+            applicationId "com.unrealgames.RacinginCar2020"
+        }
+        demo {
+            dimension "default"
+            applicationId "com.unrealgames.RacinginCar2020"
+        }
+        paid {
+            dimension "default"
+            applicationId "com.brawl.stars.box.simulator.gifts.chests"
+        }
+        mega {
+            dimension "default"
+            applicationId "com.brawl.stars.box.simulator.gifts.chests"
         }
     }
 }

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -3,7 +3,7 @@ platform :ios, '13.0'
 source 'https://cdn.cocoapods.org/'
 source 'https://github.com/cleveradssolutions/CAS-Specs.git'
 
-$casVersion = '~> 3.9.8'
+$casVersion = '~> 3.9.9'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/ios/Classes/BannerView/BannerCallback.swift
+++ b/ios/Classes/BannerView/BannerCallback.swift
@@ -17,11 +17,15 @@ class BannerCallback: MappedCallback, CASBannerDelegate {
 
     func bannerAdViewDidLoad(_ view: CASBannerView) {
         invokeMethod("onAdViewLoaded")
-        sizeListener.updateSize(view.intrinsicContentSize)
+
+        let size = view.intrinsicContentSize
+        sizeListener.updateSize(size.width, size.height)
     }
 
     func bannerAdView(_ adView: CASBannerView, didFailWith error: CASError) {
         invokeMethod("onAdViewFailed", ["error": error.message])
+
+        sizeListener.updateSize(0, 0)
     }
 
     func bannerAdView(_ adView: CASBannerView, willPresent impression: CASImpression) {

--- a/ios/Classes/BannerView/BannerSizeListener.swift
+++ b/ios/Classes/BannerView/BannerSizeListener.swift
@@ -16,19 +16,16 @@ class BannerSizeListener: MappedCallback {
         super.init(handler, id)
     }
 
-    func updateSize(_ size: CGSize) {
-        let currentWidth = size.width
-        let currentHeight = size.height
-
-        if currentWidth != lastWidth || currentHeight != lastHeight {
-            lastWidth = currentWidth
-            lastHeight = currentHeight
+    func updateSize(_ width: Double, _ height: Double) {
+        if width != lastWidth || height != lastHeight {
+            lastWidth = width
+            lastHeight = height
 
             invokeMethod(
                 "updateWidgetSize",
                 [
-                    "width": currentWidth,
-                    "height": currentHeight,
+                    "width": width,
+                    "height": height,
                 ]
             )
         }

--- a/ios/clever_ads_solutions.podspec
+++ b/ios/clever_ads_solutions.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'clever_ads_solutions'
-  s.version          = '0.7.5'
+  s.version          = '0.7.6'
   s.summary          = 'CAS.AI plugin for Flutter.'
   s.description      = <<-DESC
 CAS.AI plugin for Flutter.
@@ -20,7 +20,7 @@ CAS.AI plugin for Flutter.
   s.static_framework = true
 
   s.dependency 'Flutter'
-  s.dependency 'CleverAdsSolutions-Base', '~> 3.9.8'
+  s.dependency 'CleverAdsSolutions-Base', '~> 3.9.9'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/lib/src/banner/internal/banner_widget_state_impl.dart
+++ b/lib/src/banner/internal/banner_widget_state_impl.dart
@@ -46,7 +46,7 @@ class BannerWidgetStateImpl extends BannerWidgetState with MappedObjectImpl {
         _listener?.onLoaded();
         break;
       case 'onAdViewFailed':
-        _listener?.onFailed(call.arguments);
+        _listener?.onFailed(call.arguments['error']);
         break;
       case 'onAdViewPresented':
         _listener?.onAdViewPresented();

--- a/lib/src/cas.dart
+++ b/lib/src/cas.dart
@@ -17,7 +17,7 @@ import 'user_consent.dart';
 
 /// Represents the CAS.AI SDK.
 class CAS {
-  static const String _pluginVersion = "0.7.5";
+  static const String _pluginVersion = "0.7.6";
 
   static const MethodChannel _channel = MethodChannel("cleveradssolutions/cas");
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^4.0.0
+  flutter_lints: ^5.0.0
 
 flutter:
   plugin:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: clever_ads_solutions
 description: The CAS.AI Flutter plugin allows you to easily monetize your apps for iOS and Android using lot of Ads SDKs in mediation.
-version: 0.7.5
+version: 0.7.6
 repository: https://github.com/cleveradssolutions/CAS-Flutter
 documentation: https://github.com/cleveradssolutions/CAS-Flutter/wiki
 

--- a/tools/version_updater.py
+++ b/tools/version_updater.py
@@ -4,7 +4,7 @@ import sys
 
 
 # To run, execute the command:
-# python version_updater.py CAS_VERSION=3.9.8 FLUTTER_PLUGIN_VERSION=0.7.5
+# python version_updater.py CAS_VERSION=3.9.9 FLUTTER_PLUGIN_VERSION=0.7.6
 
 def parse_args(args):
     cas_version = None


### PR DESCRIPTION
### Features
- Wraps [Android](https://github.com/cleveradssolutions/CAS-Android/releases) and [iOS](https://github.com/cleveradssolutions/CAS-iOS/releases) 3.9.9 SDK.
### Changes
- [Android] (From DTExchange SDK update) Fixed usage of Android Advertising ID to be compliant with Google Play Ads policy.
- [iOS] Requires apps to build with Xcode 16.1 or above.
### Bug Fixes
- Fixed an issue where the banner was white.
- Fixed an issue with the wrong argument type in the `onAdViewFailed` method.