### PR TITLE
Expose lastSetUserId on TargetingOptions for per-user revenue attribution

### DIFF
--- a/lib/src/ad_content_info.dart
+++ b/lib/src/ad_content_info.dart
@@ -82,6 +82,12 @@ class AdContentInfo {
   ///
   /// The revenue value may be either estimated or exact,
   /// depending on the precision specified by [revenuePrecision].
+  ///
+  /// To attribute this revenue to a specific user for server-side
+  /// reconciliation (e.g. rewarded-ad payouts), read
+  /// `CASMobileAds.targetingOptions.lastSetUserId` inside your impression
+  /// callback. That value reflects the last userId passed to
+  /// [TargetingOptions.setUserId] or [ManagerBuilder.withUserId].
   final double revenue;
 
   /// The precision type of the revenue field.

--- a/lib/src/targeting_options.dart
+++ b/lib/src/targeting_options.dart
@@ -14,12 +14,31 @@ enum Gender {
 
 /// The App/user targeting options.
 class TargetingOptions {
+  String? _lastSetUserId;
+
+  /// The last value passed to [setUserId], or `null` if it has never been set.
+  ///
+  /// Exposed so publishers can correlate an impression fired while this
+  /// session was active with the userId they attributed to it. Useful for
+  /// rewarded-ad use cases where revenue must be reconciled per user
+  /// server-side.
+  ///
+  /// Example:
+  /// ```dart
+  /// CASMobileAds.targetingOptions.setUserId('user-123');
+  /// // ... later, in an impression callback ...
+  /// final userId = CASMobileAds.targetingOptions.lastSetUserId;
+  /// await backend.reportImpression(userId: userId, revenue: info.revenue);
+  /// ```
+  String? get lastSetUserId => _lastSetUserId;
+
   /// The userID is a unique identifier supplied by your application
   /// and must be static for each user across sessions.
   ///
   /// Your userID should not contain any personally identifiable information such as
   /// an email address, screen name, Android ID (AID), or Google Advertising ID (GAID).
   Future<void> setUserId(String? userId) {
+    _lastSetUserId = userId;
     return casInternalBridge.channel.invokeMethod("setUserId", userId);
   }
 


### PR DESCRIPTION
## Summary

Adds a `lastSetUserId` getter on `TargetingOptions` so publishers can correlate an ad impression with the userId they attributed to the session.

This is a minimal, Dart-only change (no native code, no protocol change, no behaviour change for existing callers) that unblocks a real anti-fraud use case I ran into while operating a rewarded-ad app that pays out real money.

Related issue: #53

## Motivation

I'm running a rewarded-ad Flutter app where users earn real-money rewards for watching ads. To protect against revenue spoofing (tampered clients sending fake `AdContentInfo.revenue` values to my backend), I need to reconcile per-user revenue server-side.

Today the SDK already accepts a userId:

```dart
CASMobileAds.targetingOptions.setUserId('user-123');
// or
ManagerBuilder().withUserId('user-123')...
```

…but it's write-only — there's no way to read it back, so inside an impression callback I can't answer the question _"which user did this impression belong to?"_ without threading it myself through every code path.

As discussed in #53, CAS doesn't currently offer Server-Side Verification or a per-user dimension in the Reporting API, so publishers in this situation have to do the reconciliation themselves. This small change gives us a stable hook to do that.

## What changed

### `lib/src/targeting_options.dart`
- Caches the last value passed to `setUserId(...)` in a private field.
- Exposes it as a `String? get lastSetUserId` getter with an example in the dartdoc.
- `setUserId` still calls the native channel exactly as before — only an extra local assignment.

### `lib/src/ad_content_info.dart`
- Adds a doc note on `AdContentInfo.revenue` pointing publishers to `CASMobileAds.targetingOptions.lastSetUserId` as the attribution hook. No API shape change.

### Usage pattern this enables

```dart
CASMobileAds.targetingOptions.setUserId('user-123');
// ... ad loaded and shown ...
onAdImpression: (AdContentInfo info) {
  final userId = CASMobileAds.targetingOptions.lastSetUserId;
  backend.reportImpression(
    userId: userId,
    revenue: info.revenue,
    precision: info.revenuePrecision,
    sourceUnitId: info.sourceUnitId,
    creativeId: info.creativeId,
  );
}
```

The backend can then cross-check the total of reported revenue against the aggregated `est_earnings` it gets from the CAS Reporting API (filtered by `app` + `date`) to detect clients that over-report.

## Compatibility

- No native code touched (Android/iOS/bridge untouched).
- No serialization touched.
- No public API removed or renamed.
- Default behaviour unchanged: if a publisher never calls `setUserId`, `lastSetUserId` returns `null`.
- `dart analyze` on the touched files: `No issues found!`

## Why not a bigger change?

I deliberately kept this as minimal as possible so it's obviously safe to merge. The real fix for the revenue-attribution gap is Server-Side Verification or a `user_pseudo_id` dimension in the Reporting API (see #53) — both of which need CAS-side infrastructure and aren't something I can PR from outside. This patch is the smallest thing that makes the current SDK usable for per-user reconciliation while those larger changes are considered.

Happy to iterate on naming, dartdoc wording, or to split the `ad_content_info.dart` doc-only change out if you prefer to land just the getter.